### PR TITLE
Change `OpticalStimOptions` and `OpticalStimConfig` sample rate field

### DIFF
--- a/api/nodes/optical_stim.proto
+++ b/api/nodes/optical_stim.proto
@@ -5,7 +5,7 @@ package synapse;
 message OpticalStimOptions {
   uint32 pixel_count = 1;
   repeated uint32 bit_width = 2;
-  repeated uint32 sample_rate = 3;
+  repeated uint32 refresh_rate = 3;
   repeated uint32 gain = 4;
 }
 
@@ -13,6 +13,6 @@ message OpticalStimConfig {
   uint32 peripheral_id = 1;
   repeated uint32 pixel_mask = 2;
   uint32 bit_width = 3;
-  uint32 sample_rate = 4; // frame rate
+  uint32 frame_rate = 4;
   uint32 gain = 5;
 }


### PR DESCRIPTION
Switch "sample_rate" to `refresh_rate` for `OpticalStimOptions` because this message represents available settings of the underlying display driver. Use `frame_rate` for `OpticalStimConfig` because this represents the software-defined rate that frames will be transmitted to the display.