### PR TITLE
feat: add storage and power to status, cleanup for release

### DIFF
--- a/api/node.proto
+++ b/api/node.proto
@@ -24,18 +24,6 @@ enum NodeType {
   kSpectralFilter = 8;
 }
 
-message NodeOptions {
-  NodeType type = 1;
-  uint32 id = 2;
-  oneof options {
-    ElectricalBroadbandOptions electrical_broadband = 3;
-    ElectricalStimOptions electrical_stim = 4;
-    OpticalBroadbandOptions optical_broadband = 5;
-    OpticalStimOptions optical_stim = 6;
-    SpikeDetectOptions spike_detect = 7;
-  }
-}
-
 message NodeConfig {
   NodeType type = 1;
   uint32 id = 2;

--- a/api/nodes/electrical_broadband.proto
+++ b/api/nodes/electrical_broadband.proto
@@ -1,15 +1,8 @@
 syntax = "proto3";
 
-package synapse;
-
 import "api/channel.proto";
 
-message ElectricalBroadbandOptions {
-  uint32 ch_count = 1;
-  repeated uint32 bit_width = 2;
-  repeated uint32 sample_rate = 3;
-  repeated float gain = 4;
-}
+package synapse;
 
 message ElectricalBroadbandConfig {
   uint32 peripheral_id = 1;

--- a/api/nodes/electrical_stim.proto
+++ b/api/nodes/electrical_stim.proto
@@ -1,15 +1,8 @@
 syntax = "proto3";
 
-package synapse;
-
 import "api/channel.proto";
 
-message ElectricalStimOptions {
-  uint32 ch_count = 1;
-  repeated uint32 sample_rate = 2;
-  repeated uint32 bit_width = 3;
-  repeated uint32 lsb = 4;
-}
+package synapse;
 
 message ElectricalStimConfig {
   uint32 peripheral_id = 1;

--- a/api/nodes/optical_broadband.proto
+++ b/api/nodes/optical_broadband.proto
@@ -2,16 +2,10 @@ syntax = "proto3";
 
 package synapse;
 
-message OpticalBroadbandOptions {
-  uint32 pixel_count = 1;
-  repeated uint32 bit_width = 2;
-  repeated uint32 sample_rate = 3;
-  repeated float gain = 4;
-}
-
 message OpticalBroadbandConfig {
-  repeated uint32 pixel_mask = 1;
-  uint32 bit_width = 2;
-  uint32 sample_rate = 3;
-  float gain = 4;
+  uint32 peripheral_id = 1;
+  repeated uint32 pixel_mask = 2;
+  uint32 bit_width = 3;
+  uint32 frame_rate = 4;
+  uint32 gain = 5;
 }

--- a/api/nodes/optical_stim.proto
+++ b/api/nodes/optical_stim.proto
@@ -2,13 +2,6 @@ syntax = "proto3";
 
 package synapse;
 
-message OpticalStimOptions {
-  uint32 pixel_count = 1;
-  repeated uint32 bit_width = 2;
-  repeated uint32 refresh_rate = 3;
-  repeated float gain = 4;
-}
-
 message OpticalStimConfig {
   uint32 peripheral_id = 1;
   repeated uint32 pixel_mask = 2;

--- a/api/nodes/spike_detect.proto
+++ b/api/nodes/spike_detect.proto
@@ -2,18 +2,13 @@ syntax = "proto3";
 
 package synapse;
 
-message SpikeDetectOptions {
+message SpikeDetectConfig {
   enum SpikeDetectMode {
     kThreshold = 0;
     kTemplate = 1;
     kWavelet = 2;
   }
-
-  repeated SpikeDetectMode mode = 1;
-}
-
-message SpikeDetectConfig {
-  SpikeDetectOptions.SpikeDetectMode mode = 1;
+  SpikeDetectMode mode = 1;
   uint32 threshold_uV = 2;
   repeated uint32 template_uV = 3;
   bool sort = 4;

--- a/api/nodes/stream_in.proto
+++ b/api/nodes/stream_in.proto
@@ -5,6 +5,6 @@ import "api/datatype.proto";
 package synapse;
 
 message StreamInConfig {
-  repeated uint32 shape = 1;
-  DataType data_type = 2;
+  DataType data_type = 1;
 }
+g

--- a/api/nodes/stream_out.proto
+++ b/api/nodes/stream_out.proto
@@ -4,6 +4,5 @@ package synapse;
 
 message StreamOutConfig {
   string label = 1;
-  bool use_multicast = 2;
-  string multicast_group = 3;
+  string multicast_group = 2;
 }

--- a/api/status.proto
+++ b/api/status.proto
@@ -12,7 +12,6 @@ enum StatusCode {
   kUnimplemented = 4;
   kInternalError = 5;
   kPermissionDenied = 6;
-
 }
 
 enum DeviceState {
@@ -23,11 +22,21 @@ enum DeviceState {
   kError = 4;
 }
 
+message DeviceStorage {
+  float total_gb = 1;
+  float used_gb = 2;
+}
+
+message DevicePower {
+  float battery_level_percent = 1;
+  bool is_charging = 2;
+}
+
 message Status {
   string message = 1;
   StatusCode code = 2;
   DeviceState state = 3;
   repeated NodeSocket sockets = 4;
-  uint32 battery_level = 5;
-  bool is_charging = 6;
+  DevicePower power = 5;
+  DeviceStorage storage = 6;
 }

--- a/api/synapse.proto
+++ b/api/synapse.proto
@@ -19,8 +19,7 @@ message Peripheral {
   string name = 1;
   string vendor = 2;
   uint32 peripheral_id = 3;
-  NodeOptions options = 4;
-  Type type = 5;
+  Type type = 4;
 }
 
 message DeviceInfo {


### PR DESCRIPTION
- [x] remove NodeOptions and <NodeType>Options protos
- [x] remove StreamOut `use_multicast` (it is always multicast)
- [x] remove StreamIn `shape` (NDTP packets mean this is unnecessary)
- [x] Storage and Power added to Devices's State


questions:
- should Status also report network info?