### PR TITLE
Add self-test query for device-specific health checks

### DIFF
--- a/api/query.proto
+++ b/api/query.proto
@@ -14,6 +14,10 @@ message ImpedanceQuery {
   repeated uint32 electrode_ids = 1;
 }
 
+message SelfTestQuery {
+  repeated uint32 electrode_ids = 1;
+}
+
 message ImpedanceMeasurement {
   uint32 electrode_id = 1;
   float magnitude = 2;
@@ -24,16 +28,30 @@ message ImpedanceResponse {
   repeated ImpedanceMeasurement measurements = 1;
 }
 
+message SelfTestItem {
+  string test_name = 1;
+  bool passed = 2;
+  repeated uint32 test_data = 3;
+  string test_report = 4;
+}
+
+message SelfTestResponse {
+  bool all_passed = 1;
+  repeated SelfTestItem tests = 2;
+}
+
 message QueryRequest {
   enum QueryType {
     kNone = 0;
     kImpedance = 1;
     kSample = 2;
+    kSelfTest = 3;
   }
   QueryType query_type = 1;
   oneof query {
     ImpedanceQuery impedance_query = 2;
     SampleQuery sample_query = 3;
+    SelfTestQuery self_test_query = 4;
   }
 }
 
@@ -42,5 +60,6 @@ message QueryResponse {
   repeated uint32 data = 2;
   oneof response {
     ImpedanceResponse impedance_response = 3;
+    SelfTestResponse self_test_response = 4;
   }
 }

--- a/api/query.proto
+++ b/api/query.proto
@@ -15,7 +15,7 @@ message ImpedanceQuery {
 }
 
 message SelfTestQuery {
-  repeated uint32 electrode_ids = 1;
+  repeated uint32 peripheral_id = 1;
 }
 
 message ImpedanceMeasurement {

--- a/api/query.proto
+++ b/api/query.proto
@@ -15,7 +15,7 @@ message ImpedanceQuery {
 }
 
 message SelfTestQuery {
-  repeated uint32 peripheral_id = 1;
+  uint32 peripheral_id = 1;
 }
 
 message ImpedanceMeasurement {


### PR DESCRIPTION
This adds a self-test query that can be used to return data about hardware calibration and health. An example test this query might be used for is validating a probe has all the correct register settings when it boots up.

The query message itself includes an optional field for specific electrode IDs to be used by self-tests that are conducted on specific electrodes. The response message (`SelfTestResponse`) contains a bool that is true if all tests passed. It then contains a list of `SelfTestItem` messages for each test procedure that was conducted. The `SelfTestItem` contains the name of the test, a boolean representing if the test passed, and a `test_data` field for more detailed data that the test may have collected. Finally, the `test_report` string can contain a message describing what went wrong if the test item fails. 

I kept the definition of this query intentionally broad and flexible since it is meant to be used to return hardware-specific data that may not be standardized between probes. 