### PR TITLE
Add status code to indicate a query was unable to return a valid result

### DIFF
--- a/api/status.proto
+++ b/api/status.proto
@@ -12,6 +12,7 @@ enum StatusCode {
   kUnimplemented = 4;
   kInternalError = 5;
   kPermissionDenied = 6;
+  kQueryFailed = 7;
 }
 
 enum DeviceState {


### PR DESCRIPTION
Primary use would be to indicate that a query failed not due to an internal error, but because the query was not able to find a valid result to return. The first use will be to indicate that impedance measurement of an electrode could not record an unsaturated waveform