### PR TITLE
feat: Proposal for NodeStatus messages

### DIFF
--- a/api/node.proto
+++ b/api/node.proto
@@ -48,6 +48,8 @@ message NodeStatus {
   oneof status {
     StreamOutStatus stream_out = 3;
     ElectricalBroadbandStatus electrical_broadband = 4;
+    StreamInStatus stream_in = 5;
+    ElectricalStimulationStatus electrical_stimulation = 6;
   }
 }
 

--- a/api/node.proto
+++ b/api/node.proto
@@ -42,6 +42,15 @@ message NodeConfig {
   }
 }
 
+message NodeStatus {
+  NodeType type = 1;
+  uint32 id = 2;
+  oneof status {
+    StreamOutStatus stream_out = 3;
+    ElectricalBroadbandStatus electrical_broadband = 4;
+  }
+}
+
 message NodeConnection {
   uint32 src_node_id = 1;
   uint32 dst_node_id = 2;

--- a/api/nodes/electrical_broadband.proto
+++ b/api/nodes/electrical_broadband.proto
@@ -13,3 +13,7 @@ message ElectricalBroadbandConfig {
   float low_cutoff_hz = 6;
   float high_cutoff_hz = 7;
 }
+
+message ElectricalBroadbandStatus {
+  float lsb_uV = 1;
+}

--- a/api/nodes/electrical_stimulation.proto
+++ b/api/nodes/electrical_stimulation.proto
@@ -11,3 +11,7 @@ message ElectricalStimulationConfig {
   uint32 sample_rate = 4;
   uint32 lsb = 5;
 }
+
+message ElectricalStimulationStatus {
+  float lsb_uV = 1;
+}

--- a/api/nodes/stream_in.proto
+++ b/api/nodes/stream_in.proto
@@ -8,3 +8,7 @@ message StreamInConfig {
   DataType data_type = 1;
   repeated uint32 shape = 2;
 }
+
+message StreamInStatus {
+  float throughput_mbps = 1;
+}

--- a/api/nodes/stream_out.proto
+++ b/api/nodes/stream_out.proto
@@ -6,3 +6,7 @@ message StreamOutConfig {
   string label = 1;
   string multicast_group = 2;
 }
+
+message StreamOutStatus {
+  float throughput_mbps = 1;
+}

--- a/api/status.proto
+++ b/api/status.proto
@@ -33,6 +33,10 @@ message DevicePower {
   bool is_charging = 2;
 }
 
+message SignalChainStatus {
+  repeated NodeStatus nodes = 1;
+}
+
 message Status {
   string message = 1;
   StatusCode code = 2;
@@ -40,4 +44,5 @@ message Status {
   repeated NodeSocket sockets = 4;
   DevicePower power = 5;
   DeviceStorage storage = 6;
+  SignalChainStatus signal_chain = 7;
 }


### PR DESCRIPTION
# Summary
Add a new class of messages to report node-specific status information to the client. 

## Discussion
I have proposed this new group of messages as a follow-up to previous discussion in #11. The immediate application of these status messages is to report the LSB for an ElectricalBroadbandNode. Though I believe other nodes will benefit from having a dedicated place to report status information, and I have included an example for the StreamOut node. 

This PR is meant to be an initial proposal to get the ball rolling on discussion. If its agreed we should have status messages like this, I am happy to fill out initial examples for all other Nodes. 
