### PR TITLE
feat: Add sample rate field for filter node

### DIFF
--- a/api/nodes/spectral_filter.proto
+++ b/api/nodes/spectral_filter.proto
@@ -14,4 +14,5 @@ message SpectralFilterConfig {
   SpectralFilterMethod method = 1;
   float low_cutoff_hz = 2;
   float high_cutoff_hz = 3;
+  float sample_rate_hz = 4;
 }


### PR DESCRIPTION
Digital filtering requires the sampling frequency to properly calculate filter coefficients. 