### PR TITLE
feature: Add logging endpoint for synapse devices

### DIFF
--- a/api/logging.proto
+++ b/api/logging.proto
@@ -14,7 +14,7 @@ enum LogLevel {
 }
 
 message LogEntry {
-    google.protobuf.Timestamp timestamp = 1;
+    uint64 timestamp_ns = 1;
     LogLevel level = 2;
 
     // Which entity is the source of the log (e.g. filename or module name)
@@ -24,10 +24,10 @@ message LogEntry {
 
 message LogQueryRequest {
     // Optional start time, inclusive
-    google.protobuf.Timestamp start_time = 1;
+    uint64 start_time_ns = 1;
 
     // Optional end time, exclusive
-    google.protobuf.Timestamp end_time = 2;
+    uint64 end_time_ns = 2;
 
     // Optional time since current time, in milliseconds
     // Will ignore the start and end time

--- a/api/logging.proto
+++ b/api/logging.proto
@@ -1,0 +1,46 @@
+syntax = "proto3";
+
+package synapse;
+
+import "google/protobuf/timestamp.proto";
+
+enum LogLevel {
+    LOG_LEVEL_UNKNOWN = 0;
+    LOG_LEVEL_DEBUG = 1;
+    LOG_LEVEL_INFO = 2;
+    LOG_LEVEL_WARNING = 3;
+    LOG_LEVEL_ERROR = 4;
+    LOG_LEVEL_CRITICAL = 5;
+}
+
+message LogEntry {
+    google.protobuf.Timestamp timestamp = 1;
+    LogLevel level = 2;
+
+    // Which entity is the source of the log (e.g. filename or module name)
+    string source = 3;
+    string message = 4;
+}
+
+message LogQueryRequest {
+    // Optional start time, inclusive
+    google.protobuf.Timestamp start_time = 1;
+
+    // Optional end time, exclusive
+    google.protobuf.Timestamp end_time = 2;
+
+    // Optional time since current time, in milliseconds
+    // Will ignore the start and end time
+    uint64 since_ms = 3;
+
+    // Optional minimum level, defaults to INFO
+    LogLevel min_level = 4;
+}
+
+message LogQueryResponse {
+    repeated LogEntry entries = 1;
+}
+
+message TailLogsRequest {
+    LogLevel min_level = 1;
+}

--- a/api/synapse.proto
+++ b/api/synapse.proto
@@ -7,6 +7,7 @@ import "api/node.proto";
 import "api/query.proto";
 import "api/status.proto";
 import "api/files.proto";
+import "api/logging.proto";
 
 message Peripheral {
   enum Type {
@@ -49,4 +50,6 @@ service SynapseDevice {
   rpc WriteFile(WriteFileRequest) returns (WriteFileResponse) {}
   rpc ReadFile(ReadFileRequest) returns (stream ReadFileResponse) {}
   rpc DeleteFile(DeleteFileRequest) returns (DeleteFileResponse) {}
+  rpc GetLogs(LogQueryRequest) returns (LogQueryResponse) {}
+  rpc TailLogs(TailLogsRequest) returns (stream LogEntry) {}
 }


### PR DESCRIPTION
# Summary
* Adds logging.proto
  * Defines a log entry
  * Defines requests for logs
* Adds GetLogs
* Adds TailLogs

# Discussion
* Should we discriminate on the timestamp source? I just use google's timestamp here, but we might want to describe if it is monotonic or system time (since the current SciFi device doesn't have persistent system time)