### PR TITLE
[api] Revert peripheral to be clear on source type

### DIFF
--- a/api/synapse.proto
+++ b/api/synapse.proto
@@ -12,10 +12,11 @@ import "api/logging.proto";
 message Peripheral {
   enum Type {
     kUnknown = 0;
-    kBroadbandSource = 1;
-    kElectricalStimulation = 2;
-    kOpticalStimulation = 3;
-    kSpikeSource = 4;
+    kElectricalBroadband = 1;
+    kOpticalBroadband = 2;
+    kElectricalStimulation = 3;
+    kOpticalStimulation = 4;
+    kSpikeSource = 5;
   }
   string name = 1;
   string vendor = 2;


### PR DESCRIPTION
# Summary
From @polymerizedsage 

```
I think I missed this while reviewing the API change, but these really should have stayed as separate peripheral types. There are no peripherals that support recording electrical AND optical data, so now the peripheral type doesnt actually convey information about what type of signal config should be provided.
```