### PR TITLE
fix: Use sha256 instead of md5sum

### DIFF
--- a/api/update.proto
+++ b/api/update.proto
@@ -43,8 +43,8 @@ message PackageMetadata {
     // The package size in bytes
     uint64 size = 3;
 
-    // md5sum of the package
-    string md5sum = 4;
+    // sha256 of the package
+    string sha256_sum = 4;
 }
 
 service SynapseUpdate {


### PR DESCRIPTION
# Summary
Thinking about it more, we should really just use sha256 here instead of md5sum. The additional calculation is negligible and we don't get the vulnerabilities that md5 has. 