### PR TITLE
feature: Add unicast udp transport to stream out

### DIFF
--- a/api/nodes/stream_out.proto
+++ b/api/nodes/stream_out.proto
@@ -2,25 +2,38 @@ syntax = "proto3";
 
 package synapse;
 
-// Transport specific configurations
-message UDPMulticastConfig {
-  string group = 1;
-  uint32 port = 2;
-}
-
+/**
+ * UDPUnicastConfig defines the configuration parameters for UDP unicast transport.
+ */
 message UDPUnicastConfig {
+  // IPv4 or IPv6 address of the destination endpoint
   string destination_address = 1;
+
+  // Destination port number, 0 to 65535
   uint32 destination_port = 2;
 }
 
+/**
+ * StreamOutConfig defines the configuration for an outbound data stream.
+ * Clients can request to create a new outbound stream by providing a transport
+ */
 message StreamOutConfig {
+  // Human-readable identifier for the stream
   string label = 1;
+
+  // Transport-specific configuration
+  // Only one transport type can be specified at a time
   oneof transport {
-    UDPMulticastConfig udp_multicast = 2;
-    UDPUnicastConfig udp_unicast = 3;
+    // Configure for UDP unicast support. Only one destination is supported
+    UDPUnicastConfig udp_unicast = 2;
   }
 }
 
+/**
+ * StreamOutStatus provides status information for an outbound stream.
+ * It contains data about the instantaneous performance of the stream
+ */
 message StreamOutStatus {
+  // Current throughput of the stream in megabits per second
   float throughput_mbps = 1;
 }

--- a/api/nodes/stream_out.proto
+++ b/api/nodes/stream_out.proto
@@ -2,9 +2,23 @@ syntax = "proto3";
 
 package synapse;
 
+// Transport specific configurations
+message UDPMulticastConfig {
+  string group = 1;
+  uint32 port = 2;
+}
+
+message UDPUnicastConfig {
+  string destination_address = 1;
+  uint32 destination_port = 2;
+}
+
 message StreamOutConfig {
   string label = 1;
-  string multicast_group = 2;
+  oneof transport {
+    UDPMulticastConfig udp_multicast = 2;
+    UDPUnicastConfig udp_unicast = 3;
+  }
 }
 
 message StreamOutStatus {

--- a/api/nodes/stream_out.proto
+++ b/api/nodes/stream_out.proto
@@ -36,4 +36,7 @@ message StreamOutConfig {
 message StreamOutStatus {
   // Current throughput of the stream in megabits per second
   float throughput_mbps = 1;
+
+  // How many failed packet sends have happened since the start of the stream
+  uint64 failed_send_count = 2;
 }


### PR DESCRIPTION
# Summary
As we have discussed, multicast has its issues when streaming high bandwidth data over Wifi. We have tested unicast udp as an alternative transport with pretty good success. 

# Changes
  * Adds a specific UDP Multicast Configuration (for multicast if we ever want to support it again)
  * Adds a Unicast UDP configuration. The client will tell the server which port and address to stream the data to
  * bundles these in a transport option. we can extend this to different transports, like tcp, later

# Testing
  * CI passes.