### PR TITLE
Change filter corner name fields.

### DIFF
--- a/api/nodes/signal_config.proto
+++ b/api/nodes/signal_config.proto
@@ -7,8 +7,8 @@ package synapse;
 message ElectrodeConfig {
     repeated Channel channels = 1;
     reserved 2, 3;
-    float low_pass_cutoff_hz = 4;
-    float high_pass_cutoff_hz = 5;
+    float low_pass_corner_hz = 4;
+    float high_pass_corner_hz = 5;
 }
 
 message PixelConfig {

--- a/api/nodes/signal_config.proto
+++ b/api/nodes/signal_config.proto
@@ -6,8 +6,9 @@ package synapse;
 
 message ElectrodeConfig {
     repeated Channel channels = 1;
-    float low_cutoff_hz = 2;
-    float high_cutoff_hz = 3;
+    reserved 2, 3;
+    float low_pass_cutoff_hz = 4;
+    float high_pass_cutoff_hz = 5;
 }
 
 message PixelConfig {

--- a/api/nodes/spectral_filter.proto
+++ b/api/nodes/spectral_filter.proto
@@ -13,6 +13,6 @@ enum SpectralFilterMethod {
 message SpectralFilterConfig {
   SpectralFilterMethod method = 1;
   reserved 2, 3;
-  float low_pass_hz = 4;
-  float high_pass_hz = 5;
+  float low_pass_corner_hz = 4;
+  float high_pass_corner_hz = 5;
 }

--- a/api/nodes/spectral_filter.proto
+++ b/api/nodes/spectral_filter.proto
@@ -12,6 +12,7 @@ enum SpectralFilterMethod {
 
 message SpectralFilterConfig {
   SpectralFilterMethod method = 1;
-  float low_cutoff_hz = 2;
-  float high_cutoff_hz = 3;
+  reserved 2, 3;
+  float low_pass_hz = 4;
+  float high_pass_hz = 5;
 }


### PR DESCRIPTION
Users have mentioned a few times now that "low cutoff" and "high cutoff" are confusing. Most people with EE or signal processing experience expect filters to be referred to by their pass band, not their stop band. This changes field names but does not change their functionality. 

I marked the previous tag numbers as reserved but I am not sure if this is strictly necessary since they are just being renamed.