### PR TITLE
feature: add streamed query responses

### DIFF
--- a/api/query.proto
+++ b/api/query.proto
@@ -22,6 +22,7 @@ message ImpedanceMeasurement {
   uint32 electrode_id = 1;
   float magnitude = 2;
   float phase = 3;
+  float stim_frequency_hz = 4;
 }
 
 message ImpedanceResponse {
@@ -55,11 +56,28 @@ message QueryRequest {
   }
 }
 
+message StreamQueryRequest {
+  QueryRequest request = 1;
+
+  // Other options to fill in specific to a stream
+}
+
 message QueryResponse {
   Status status = 1;
   repeated uint32 data = 2;
   oneof response {
     ImpedanceResponse impedance_response = 3;
     SelfTestResponse self_test_response = 4;
+  }
+}
+
+message StreamQueryResponse {
+  StatusCode code = 1;
+  uint64 timestamp_ns = 2;
+
+  // We need to switch on the test being run
+  oneof response {
+    ImpedanceResponse impedance = 3;
+    SelfTestResponse self_test = 4;
   }
 }

--- a/api/query.proto
+++ b/api/query.proto
@@ -22,7 +22,6 @@ message ImpedanceMeasurement {
   uint32 electrode_id = 1;
   float magnitude = 2;
   float phase = 3;
-  float stim_frequency_hz = 4;
 }
 
 message ImpedanceResponse {

--- a/api/query.proto
+++ b/api/query.proto
@@ -73,11 +73,12 @@ message QueryResponse {
 
 message StreamQueryResponse {
   StatusCode code = 1;
-  uint64 timestamp_ns = 2;
-
+  string message = 2;
+  uint64 timestamp_ns = 3;
+  
   // We need to switch on the test being run
   oneof response {
-    ImpedanceResponse impedance = 3;
-    SelfTestResponse self_test = 4;
+    ImpedanceResponse impedance = 4;
+    SelfTestResponse self_test = 5;
   }
 }

--- a/api/synapse.proto
+++ b/api/synapse.proto
@@ -45,6 +45,7 @@ service SynapseDevice {
   rpc Start(google.protobuf.Empty) returns (Status) {}
   rpc Stop(google.protobuf.Empty) returns (Status) {}
   rpc Query(QueryRequest) returns (QueryResponse) {}
+  rpc StreamQuery(StreamQueryRequest) returns (stream StreamQueryResponse) {}
 
   rpc ListFiles(google.protobuf.Empty) returns (ListFilesResponse) {}
   rpc WriteFile(WriteFileRequest) returns (WriteFileResponse) {}


### PR DESCRIPTION
# Summary
In order to achieve real time feedback on query, we add a stream option.

Note: the unary calls are left until we switch over completely as to not break backwards compatibility. 