### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+# Summary
+Brief overview of the changes
+
+# Changes
+* Detailed breakdown of what changed and why. If there are new/changed API concepts, explain how they are meant to be used.
+
+# Testing
+How can this change be tested?
+
+Please provide a link to a reference server and client implementation in synapse-python.


### PR DESCRIPTION
I've added a PR template to help guide the additions of new features of the API. Notably I have added that API changes should have working reference implementations in synapse-python before being approved. 