### PR TITLE
Unified SpikeDetector node with two data outputs

### DIFF
--- a/api/node.proto
+++ b/api/node.proto
@@ -12,9 +12,9 @@ import "api/nodes/stream_out.proto";
 import "api/nodes/stream_in.proto";
 import "api/nodes/disk_writer.proto";
 import "api/nodes/spike_source.proto";
-import "api/nodes/spike_binner.proto";
 
 enum NodeType {
+  reserved 13;
   kNodeTypeUnknown = 0;
   kStreamIn = 1;
   kStreamOut = 2;
@@ -25,10 +25,10 @@ enum NodeType {
   kSpikeSource = 7;
   kSpectralFilter = 8;
   kDiskWriter = 9;
-  kSpikeBinner = 10;
 }
 
 message NodeConfig {
+  reserved 13;
   NodeType type = 1;
   uint32 id = 2;
   oneof config {
@@ -41,7 +41,6 @@ message NodeConfig {
     SpectralFilterConfig spectral_filter = 10;
     DiskWriterConfig disk_writer = 11;
     SpikeSourceConfig spike_source = 12;
-    SpikeBinnerConfig spike_binner = 13;
   }
 }
 

--- a/api/nodes/spike_binner.proto
+++ b/api/nodes/spike_binner.proto
@@ -1,7 +1,0 @@
-syntax = "proto3";
-
-package synapse;
-
-message SpikeBinnerConfig {
-  uint32 bin_size_ms = 1;
-}

--- a/api/nodes/spike_detector.proto
+++ b/api/nodes/spike_detector.proto
@@ -15,5 +15,6 @@ message SpikeDetectorConfig {
     Thresholder thresholder = 1;
     TemplateMatcher template_matcher = 2;
   }
-  uint32 samples_per_spike = 3;
+  uint32 samples_per_spike = 3; // The number of samples to send as the spike waveform when a spike is detected. Disables waveform capture if set to 0.
+  uint32 bin_size_ms = 4; // The bin size in milliseconds for the binned spike output. Disables spike binning if set to 0.
 }


### PR DESCRIPTION
# Summary
This is a proposed change to implement make the SpikeDetector and SpikeBinner a single node. This node would output both binned spike data and spike waveforms. This would resolve the issue with a independent SpikeDetector and SpikeBinner that arises from the SpikeBinner losing sample timing information. 

# Changes
- Removes SpikeBinner
- Adds bin size parameter to SpikeDetector

# Testing
Reference implementation TBD
