### PR TITLE
[feature] Add TimeSyncPacket to Synapse API to support software time synchronization

### DIFF
--- a/api/status.proto
+++ b/api/status.proto
@@ -45,4 +45,8 @@ message Status {
   DevicePower power = 5;
   DeviceStorage storage = 6;
   SignalChainStatus signal_chain = 7;
+
+  // If the device supports a time sync server (see time.proto)
+  // Then the UDP echo server will be available at this port
+  uint32 time_sync_port = 8; // Port number (0-65535) for the UDP time sync server
 }

--- a/api/time.proto
+++ b/api/time.proto
@@ -2,6 +2,31 @@ syntax = "proto3";
 
 package synapse;
 
+/**
+ * Used for precise time synchronization over UDP between clients and a server
+ * In most cases, the server is the Synapse device.enum
+ * 
+ * How it works:
+ *  1. Client generates a random client_id on first connection
+ *  2. Client increments the sequence number on each packet (to detect drops)
+ *  3. Client records the send time and sends the packet to the server over udp.
+ *    - The server port will be available through the Status message
+ *    - Try to timestamp the packet as close as possible to the send to minimize
+ *      the calculated offset error. Future improvements could support hardware timestamps
+ *  4. Server records the receive time
+ *  5. Server immediately echos it back to the client, recording the send time
+ *  6. Client records the receive time when the packet returns
+ * 
+ * With these times, the client can calculate
+ *  - Round Trip Time: (client_receive_time_ns - client_send_time_ns)
+ *  - Network Latency (assumes symmetric paths): rtt / 2
+ *  - Clock offset: https://en.wikipedia.org/wiki/Network_Time_Protocol#Clock_synchronization_algorithm
+ * 
+ * Implementation notes:
+ *  - All timestamps are monotonic nanoseconds since Unix epoch
+ *  - The server acts as a passive reflector
+ *  - Multiple sync packets (8 or so) should be sent with a short period (200 ms) between
+*/
 message TimeSyncPacket {
     fixed32 client_id = 1;
     fixed32 sequence = 2;

--- a/api/time.proto
+++ b/api/time.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package synapse;
+
+message TimeSyncPacket {
+    fixed32 client_id = 1;
+    fixed32 sequence = 2;
+
+    fixed64 client_send_time_ns = 3;
+    fixed64 server_receive_time_ns = 4;
+    fixed64 server_send_time_ns = 5;
+    fixed64 client_receive_time_ns = 6;
+}


### PR DESCRIPTION
# Summary
In order to support synchronized time stamps in client and synapse devices, we support an NTP like TimeSyncPacket which allows for clock sync in software.

More details can be found here: https://en.wikipedia.org/wiki/Network_Time_Protocol#Clock_synchronization_algorithm

# Changes
* Updates Status to include an optional time_sync_port to indicate time syncing capabilities
* added time.proto with the TimeSyncPacket 

# Testing
* Tested with SciFi - was able to implement a client and server. 
