### PR TITLE
feat: Add controller node with output tensor

### DIFF
--- a/api/datatype.proto
+++ b/api/datatype.proto
@@ -36,12 +36,18 @@ message Tensor {
         DT_INT32 = 9;
         DT_INT64 = 10;
         DT_BOOL = 11;
-        DT_STRING = 12;
     }
     DType dtype = 3;
+
+    enum Endianness {
+        LITTLE_ENDIAN = 0;
+        BIG_ENDIAN = 1;
+    }
+    // We default to little because that covers most of the use cases
+    Endianness endianness = 4;
 
     // Data, stored in a flat array, see shape to reconstruct
     // e.g. shape: [1, 3] would be:
     // [10.0, 20.0, 30.0]
-    bytes data = 4;
+    bytes data = 5;
 }

--- a/api/datatype.proto
+++ b/api/datatype.proto
@@ -11,3 +11,31 @@ enum DataType {
     kImage = 5;
     kWaveforms = 6;
 }
+
+// A simple tensor with timestamped data
+message Tensor {
+    // Timestamp in ns since the unix epoch
+    uint64 timestamp_ns = 1;
+
+    // Shape of the tensor
+    // The number of values should equal to the product of the dimensions
+    // e.g. shape = [2, 3] => 2 rows, 3 columns
+    repeated int32 shape = 2;
+
+    // Data, stored in a flat array, see shape to reconstruct
+    // e.g. shape: [1, 3] would be:
+    // [10.0, 20.0, 30.0]
+    repeated float values = 3;
+
+    // Expected data type to parse out
+    enum DType {
+        kFloat32 = 0;
+        kInt32 = 1;
+        kUint8 = 2;
+        // e.g. float 64
+        kDouble = 3;
+        kInt64 = 4;
+        kBool = 5;
+    }
+    DType dtype = 4;
+}

--- a/api/datatype.proto
+++ b/api/datatype.proto
@@ -22,20 +22,26 @@ message Tensor {
     // e.g. shape = [2, 3] => 2 rows, 3 columns
     repeated int32 shape = 2;
     
+    // Expected data type to parse out
+    enum DType {
+        DT_INVALID = 0;
+        DT_FLOAT = 1;
+        DT_DOUBLE = 2;
+        DT_UINT8 = 3;
+        DT_UINT16 = 4;
+        DT_UINT32 = 5;
+        DT_UINT64 = 6;
+        DT_INT8 = 7;
+        DT_INT16 = 8;
+        DT_INT32 = 9;
+        DT_INT64 = 10;
+        DT_BOOL = 11;
+        DT_STRING = 12;
+    }
+    DType dtype = 3;
+
     // Data, stored in a flat array, see shape to reconstruct
     // e.g. shape: [1, 3] would be:
     // [10.0, 20.0, 30.0]
-    repeated float values = 3;
-    
-    // Expected data type to parse out
-    enum DType {
-        kFloat32 = 0;
-        kInt32 = 1;
-        kUint8 = 2;
-        // e.g. float 64
-        kDouble = 3;
-        kInt64 = 4;
-        kBool = 5;
-    }
-    DType dtype = 4;
+    bytes data = 4;
 }

--- a/api/datatype.proto
+++ b/api/datatype.proto
@@ -16,17 +16,17 @@ enum DataType {
 message Tensor {
     // Timestamp in ns since the unix epoch
     uint64 timestamp_ns = 1;
-
+    
     // Shape of the tensor
     // The number of values should equal to the product of the dimensions
     // e.g. shape = [2, 3] => 2 rows, 3 columns
     repeated int32 shape = 2;
-
+    
     // Data, stored in a flat array, see shape to reconstruct
     // e.g. shape: [1, 3] would be:
     // [10.0, 20.0, 30.0]
     repeated float values = 3;
-
+    
     // Expected data type to parse out
     enum DType {
         kFloat32 = 0;

--- a/api/node.proto
+++ b/api/node.proto
@@ -13,6 +13,7 @@ import "api/nodes/stream_in.proto";
 import "api/nodes/disk_writer.proto";
 import "api/nodes/spike_source.proto";
 import "api/nodes/spike_binner.proto";
+import "api/nodes/controller.proto";
 
 enum NodeType {
   kNodeTypeUnknown = 0;
@@ -26,6 +27,7 @@ enum NodeType {
   kSpectralFilter = 8;
   kDiskWriter = 9;
   kSpikeBinner = 10;
+  kController = 11;
 }
 
 message NodeConfig {
@@ -42,6 +44,7 @@ message NodeConfig {
     DiskWriterConfig disk_writer = 11;
     SpikeSourceConfig spike_source = 12;
     SpikeBinnerConfig spike_binner = 13;
+    ControllerNodeConfig controller = 14;
   }
 }
 

--- a/api/nodes/controller.proto
+++ b/api/nodes/controller.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package synapse;
+
+message ControllerNodeConfig {
+    
+}


### PR DESCRIPTION
# Summary
We are starting more BCI experiments that need flexbility in the output. So, add an output tensor message.

Also, add stubs for the ControllerNode concept. It is empty now, but it allows us to init a ControllerNode type. 

# Changes
* Adds Tensor
* Adds Controller node type

# Testing
 - https://github.com/sciencecorp/synapse-python/pull/103
