### PR TITLE
feat: Add Tap API 

### DIFF
--- a/api/synapse.proto
+++ b/api/synapse.proto
@@ -39,6 +39,29 @@ message DeviceConfiguration {
   repeated NodeConnection connections = 2;
 }
 
+message CreateTapRequest {
+  // Which node to tap the output from
+  uint32 node_id = 1;
+
+  // Client address to the send data to
+  string client_address = 2;
+
+  // Client port to send data to
+  uint32 client_port = 3;
+
+  // What type of data should we get
+  enum TapType {
+    kUnknown = 0;
+    kNodeStats = 1;
+    kNodeOutput = 2;
+  }
+  TapType tap_type = 4;
+}
+
+message CreateTapResponse {
+  StatusCode code = 1;
+}
+
 service SynapseDevice {
   rpc Info(google.protobuf.Empty) returns (DeviceInfo) {}
   rpc Configure(DeviceConfiguration) returns (Status) {}
@@ -53,4 +76,6 @@ service SynapseDevice {
   rpc DeleteFile(DeleteFileRequest) returns (DeleteFileResponse) {}
   rpc GetLogs(LogQueryRequest) returns (LogQueryResponse) {}
   rpc TailLogs(TailLogsRequest) returns (stream LogEntry) {}
+
+  rpc CreateTap(CreateTapRequest) returns (CreateTapResponse) {}
 }

--- a/api/synapse.proto
+++ b/api/synapse.proto
@@ -39,6 +39,10 @@ message DeviceConfiguration {
   repeated NodeConnection connections = 2;
 }
 
+message TapDownsampleOptions {
+  
+}
+
 message CreateTapRequest {
   // Which node to tap the output from
   uint32 node_id = 1;
@@ -49,18 +53,24 @@ message CreateTapRequest {
   // Client port to send data to
   uint32 client_port = 3;
 
-  // What type of data should we get
-  enum TapType {
-    kUnknown = 0;
-    kNodeStats = 1;
-    kNodeOutput = 2;
-  }
-  TapType tap_type = 4;
+  // Downsample options specific to this tap
+  TapDownsampleOptions downsample_options = 4;
 }
 
 message CreateTapResponse {
   StatusCode code = 1;
 }
+
+message RemoveTapRequest {
+  uint32 node_id = 1;
+  string client_address = 2;
+  uint32 client_port = 3;
+}
+
+message RemoveTapResponse {
+  StatusCode code = 1;
+}
+
 
 service SynapseDevice {
   rpc Info(google.protobuf.Empty) returns (DeviceInfo) {}
@@ -78,4 +88,5 @@ service SynapseDevice {
   rpc TailLogs(TailLogsRequest) returns (stream LogEntry) {}
 
   rpc CreateTap(CreateTapRequest) returns (CreateTapResponse) {}
+  rpc RemoveTap(RemoveTapRequest) returns (RemoveTapResponse) {}
 }

--- a/api/synapse.proto
+++ b/api/synapse.proto
@@ -8,6 +8,7 @@ import "api/query.proto";
 import "api/status.proto";
 import "api/files.proto";
 import "api/logging.proto";
+import "api/tap.proto";
 
 message Peripheral {
   enum Type {
@@ -38,39 +39,6 @@ message DeviceConfiguration {
   repeated NodeConfig nodes = 1;
   repeated NodeConnection connections = 2;
 }
-
-message TapDownsampleOptions {
-  
-}
-
-message CreateTapRequest {
-  // Which node to tap the output from
-  uint32 node_id = 1;
-
-  // Client address to the send data to
-  string client_address = 2;
-
-  // Client port to send data to
-  uint32 client_port = 3;
-
-  // Downsample options specific to this tap
-  TapDownsampleOptions downsample_options = 4;
-}
-
-message CreateTapResponse {
-  StatusCode code = 1;
-}
-
-message RemoveTapRequest {
-  uint32 node_id = 1;
-  string client_address = 2;
-  uint32 client_port = 3;
-}
-
-message RemoveTapResponse {
-  StatusCode code = 1;
-}
-
 
 service SynapseDevice {
   rpc Info(google.protobuf.Empty) returns (DeviceInfo) {}

--- a/api/tap.proto
+++ b/api/tap.proto
@@ -1,0 +1,65 @@
+syntax = "proto3";
+
+package synapse;
+
+import "api/status.proto";
+
+enum TapTransportType {
+    TAP_TRANSPORT_UNKNOWN = 0;
+
+    // A simple udp stream out, no reliability 
+    TAP_TRANSPORT_UDP = 1;
+
+    // ZMQ publisher out
+    TAP_TRANSPORT_ZMQ = 2;
+}
+
+message TapTransportUDP {
+    // Client address and port to stream data to
+    string address = 1;
+    uint32 port = 2;
+}
+
+message TapTransportZMQ {
+    // The connection to listen to
+    string connection = 1;
+
+    // Optional topic to filter on
+    string topic = 2;
+}
+
+message TapTransportConfig {
+    TapTransportType transport_type = 1;
+    oneof transport_config {
+        TapTransportUDP udp = 2;
+        TapTransportZMQ zmq = 3;
+    }
+}
+
+message TapDownsampleOptions {
+  
+}
+
+message CreateTapRequest {
+  // Which node to tap the output from
+  uint32 node_id = 1;
+  TapTransportConfig tap_config = 2;
+
+  // Downsample options specific to this tap
+  TapDownsampleOptions downsample_options = 3;
+}
+
+message CreateTapResponse {
+  StatusCode code = 1;
+}
+
+message RemoveTapRequest {
+  uint32 node_id = 1;
+
+  // The configuration to remove
+  TapTransportConfig tap_config = 2;
+}
+
+message RemoveTapResponse {
+  StatusCode code = 1;
+}


### PR DESCRIPTION
# Summary
We would like to be able to listen and eventually write to nodes in a signal chain. Create the initial tap API for us to build on. 

# Changes
* Adds tap.proto
* Adds a create tap and remove tap endpoint

# Testing
 - Working implementation with the SciFi repo will be up for review
