### PR TITLE
feat: Broadband Frame data type

### DIFF
--- a/api/nodes/broadband_source.proto
+++ b/api/nodes/broadband_source.proto
@@ -18,3 +18,16 @@ message BroadbandSourceConfig {
 message BroadbandSourceStatus {
     SignalStatus status = 1;
 }
+
+// A sample of all of the channels at a specific timepoint
+message BroadbandFrame {
+  // Monotonic timestamp when this frame was recorded
+  uint64 timestamp_ns = 1;
+
+  // Monotonically increasing sequence number
+  // useful to detect missed or dropped frames
+  uint64 sequence_number = 2;
+
+  // The actual frame data, indexed by channel id
+  repeated sint32 frame_data = 3;
+}


### PR DESCRIPTION
# Summary
We need some way for users to consume broadband frame data. This protobuf allows that to happen. Inspired by our internal MyelinFrame, but with a sequence number.

# Changes
* Adds BroadbandFrame message type

# Testing
 - Example application in follow up