### PR TITLE
feat: rename controller node to application node

### DIFF
--- a/api/node.proto
+++ b/api/node.proto
@@ -13,7 +13,7 @@ import "api/nodes/stream_in.proto";
 import "api/nodes/disk_writer.proto";
 import "api/nodes/spike_source.proto";
 import "api/nodes/spike_binner.proto";
-import "api/nodes/controller.proto";
+import "api/nodes/application.proto";
 
 enum NodeType {
   kNodeTypeUnknown = 0;
@@ -27,7 +27,7 @@ enum NodeType {
   kSpectralFilter = 8;
   kDiskWriter = 9;
   kSpikeBinner = 10;
-  kController = 11;
+  kApplication = 11;
 }
 
 message NodeConfig {
@@ -44,7 +44,7 @@ message NodeConfig {
     DiskWriterConfig disk_writer = 11;
     SpikeSourceConfig spike_source = 12;
     SpikeBinnerConfig spike_binner = 13;
-    ControllerNodeConfig controller = 14;
+    ApplicationNodeConfig application = 14;
   }
 }
 
@@ -56,6 +56,7 @@ message NodeStatus {
     BroadbandSourceStatus broadband_source = 4;
     StreamInStatus stream_in = 5;
     ElectricalStimulationStatus electrical_stimulation = 6;
+    ApplicationNodeStatus application = 7;
   }
 }
 

--- a/api/nodes/application.proto
+++ b/api/nodes/application.proto
@@ -1,0 +1,15 @@
+syntax = "proto3";
+
+package synapse;
+
+message ApplicationNodeConfig {
+    // Your application name, it should match what is deployed
+    string name = 1;
+}
+
+message ApplicationNodeStatus {
+    string name = 1;
+
+    // Is the application started and running?
+    bool running = 2;
+}

--- a/api/nodes/controller.proto
+++ b/api/nodes/controller.proto
@@ -1,7 +1,0 @@
-syntax = "proto3";
-
-package synapse;
-
-message ControllerNodeConfig {
-    
-}


### PR DESCRIPTION
# Summary
Controller node wasn't very descriptive, we think application is more apt for what this node will be doing. Since we haven't actually integrated the previous ControllerNode type, there is no risk in making this update. 

# Changes
* Renamed Controller to Application

# Testing
 - builds
