### PR TITLE
feature: Read tap management

### DIFF
--- a/api/query.proto
+++ b/api/query.proto
@@ -4,6 +4,7 @@ package synapse;
 
 import "api/channel.proto";
 import "api/status.proto";
+import "api/tap.proto";
 
 message SampleQuery {
   repeated Channel channels = 1;
@@ -46,12 +47,14 @@ message QueryRequest {
     kImpedance = 1;
     kSample = 2;
     kSelfTest = 3;
+    kListTaps = 4;
   }
   QueryType query_type = 1;
   oneof query {
     ImpedanceQuery impedance_query = 2;
     SampleQuery sample_query = 3;
     SelfTestQuery self_test_query = 4;
+    ListTapsQuery list_taps_query = 5;
   }
 }
 
@@ -67,6 +70,7 @@ message QueryResponse {
   oneof response {
     ImpedanceResponse impedance_response = 3;
     SelfTestResponse self_test_response = 4;
+    ListTapsResponse list_taps_response = 5;
   }
 }
 

--- a/api/synapse.proto
+++ b/api/synapse.proto
@@ -8,6 +8,7 @@ import "api/query.proto";
 import "api/status.proto";
 import "api/files.proto";
 import "api/logging.proto";
+import "api/tap.proto";
 
 message Peripheral {
   enum Type {
@@ -53,4 +54,7 @@ service SynapseDevice {
   rpc DeleteFile(DeleteFileRequest) returns (DeleteFileResponse) {}
   rpc GetLogs(LogQueryRequest) returns (LogQueryResponse) {}
   rpc TailLogs(TailLogsRequest) returns (stream LogEntry) {}
+
+  // List all available taps to connect to and listen to data
+  rpc ListTaps(ListTapsRequest) returns (ListTapsResponse) {}
 }

--- a/api/synapse.proto
+++ b/api/synapse.proto
@@ -8,7 +8,6 @@ import "api/query.proto";
 import "api/status.proto";
 import "api/files.proto";
 import "api/logging.proto";
-import "api/tap.proto";
 
 message Peripheral {
   enum Type {
@@ -54,7 +53,4 @@ service SynapseDevice {
   rpc DeleteFile(DeleteFileRequest) returns (DeleteFileResponse) {}
   rpc GetLogs(LogQueryRequest) returns (LogQueryResponse) {}
   rpc TailLogs(TailLogsRequest) returns (stream LogEntry) {}
-
-  // List all available taps to connect to and listen to data
-  rpc ListTaps(ListTapsRequest) returns (ListTapsResponse) {}
 }

--- a/api/tap.proto
+++ b/api/tap.proto
@@ -13,7 +13,7 @@ message TapConnection {
     string message_type = 3;
 }
 
-message ListTapsRequest {
+message ListTapsQuery {
 
 }
 

--- a/api/tap.proto
+++ b/api/tap.proto
@@ -1,0 +1,22 @@
+syntax = "proto3";
+
+package synapse;
+
+message TapConnection {
+    // Unique name id for this tap
+    string name = 1;
+
+    // What is the zmq endpoint to connect to
+    string endpoint = 2;
+
+    // What is the protobuf message to expect over this 
+    string message_type = 3;
+}
+
+message ListTapsRequest {
+
+}
+
+message ListTapsResponse {
+    repeated TapConnection taps = 1;
+}


### PR DESCRIPTION
# Summary
In this iteration, we focus on read taps that are connected under the hood using zmq. We allow users to list the endpoints that taps are being published from.

# Changes
* Added tap.proto

# Testing
 - builds, being used for synapse devices.
