### PR TITLE
feature: Remove device configuration from app manifest

### DIFF
--- a/api/app.proto
+++ b/api/app.proto
@@ -2,12 +2,7 @@ syntax = "proto3";
 
 package synapse;
 
-import "api/synapse.proto";
-
 message AppManifest {
   // Your application name
   string name = 1;
-
-  // The device configuration for this app
-  DeviceConfiguration device_configuration = 2;
 }


### PR DESCRIPTION
# Summary
We realized that the device configuration is duplicated, and can change between deployments/starts/stops. This minimizes the amount of information in the manifest. 

# Changes
* removed device_configuration field. No one was using this api, so it does not break anything

# Testing
 - N/A