### PR TITLE
add app deployment to control plane api

### DIFF
--- a/api/app.proto
+++ b/api/app.proto
@@ -2,7 +2,13 @@ syntax = "proto3";
 
 package synapse;
 
+import "api/status.proto";
+
 message AppManifest {
   // Your application name
   string name = 1;
 }
+
+message AppDeployRequest { bytes body = 1; }
+
+message AppDeployResponse { Status status = 1; }

--- a/api/app.proto
+++ b/api/app.proto
@@ -9,6 +9,32 @@ message AppManifest {
   string name = 1;
 }
 
-message AppDeployRequest { bytes body = 1; }
+message PackageMetadata {
+  // the package name
+  // e.g. synapse-example-app_0.1.0_arm64.deb
+  string name = 1;
 
-message AppDeployResponse { Status status = 1; }
+  // The version of the package to be uploaded
+  string version = 2;
+
+  // Package size, in bytes
+  uint64 size = 3;
+
+  // sha256 of the package, for verification
+  string sha256_sum = 4;
+}
+
+message AppPackageChunk {
+  // The first chunk is the metadata, with subsequent chunks being the file to install
+  oneof data {
+    PackageMetadata metadata = 1;
+    bytes file_chunk = 2;
+  }
+}
+
+message AppDeployResponse { 
+  StatusCode status = 1;
+
+  // Informational messages
+  string message = 2;
+}

--- a/api/synapse.proto
+++ b/api/synapse.proto
@@ -9,6 +9,7 @@ import "api/status.proto";
 import "api/files.proto";
 import "api/logging.proto";
 import "api/app.proto";
+
 message Peripheral {
   enum Type {
     kUnknown = 0;

--- a/api/synapse.proto
+++ b/api/synapse.proto
@@ -8,7 +8,7 @@ import "api/query.proto";
 import "api/status.proto";
 import "api/files.proto";
 import "api/logging.proto";
-
+import "api/app.proto";
 message Peripheral {
   enum Type {
     kUnknown = 0;
@@ -47,10 +47,13 @@ service SynapseDevice {
   rpc Query(QueryRequest) returns (QueryResponse) {}
   rpc StreamQuery(StreamQueryRequest) returns (stream StreamQueryResponse) {}
 
+  rpc DeployApp(AppDeployRequest) returns (AppDeployResponse) {}
+
   rpc ListFiles(google.protobuf.Empty) returns (ListFilesResponse) {}
   rpc WriteFile(WriteFileRequest) returns (WriteFileResponse) {}
   rpc ReadFile(ReadFileRequest) returns (stream ReadFileResponse) {}
   rpc DeleteFile(DeleteFileRequest) returns (DeleteFileResponse) {}
+
   rpc GetLogs(LogQueryRequest) returns (LogQueryResponse) {}
   rpc TailLogs(TailLogsRequest) returns (stream LogEntry) {}
 }

--- a/api/synapse.proto
+++ b/api/synapse.proto
@@ -48,7 +48,7 @@ service SynapseDevice {
   rpc Query(QueryRequest) returns (QueryResponse) {}
   rpc StreamQuery(StreamQueryRequest) returns (stream StreamQueryResponse) {}
 
-  rpc DeployApp(AppDeployRequest) returns (AppDeployResponse) {}
+  rpc DeployApp(stream AppPackageChunk) returns (stream AppDeployResponse) {}
 
   rpc ListFiles(google.protobuf.Empty) returns (ListFilesResponse) {}
   rpc WriteFile(WriteFileRequest) returns (WriteFileResponse) {}


### PR DESCRIPTION
# Summary
Right now app deployment involves using ssh and remote controlling the headstage OS; having an easily accessible shell like this substantially exposes the attack surface area and also is just less reliable.

# Changes
* This PR adds a `DeployApp` method to the Synapse Control Plane API which allows the client to send the `.deb` file as a byte array, which will then be validated and installed atomically on the device side.