### PR TITLE
Feature: Add configuration struct to application config

### DIFF
--- a/api/nodes/application.proto
+++ b/api/nodes/application.proto
@@ -2,9 +2,15 @@ syntax = "proto3";
 
 package synapse;
 
+import "google/protobuf/struct.proto";
+
 message ApplicationNodeConfig {
     // Your application name, it should match what is deployed
     string name = 1;
+
+    // Application specific configuration, will be loaded by
+    // the custom application during runtime
+    google.protobuf.Struct parameters = 2;
 }
 
 message ApplicationNodeStatus {

--- a/api/nodes/application.proto
+++ b/api/nodes/application.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package synapse;
 
-import "google/protobuf/struct.proto";
+import "google/protobuf/any.proto";
 
 message ApplicationNodeConfig {
     // Your application name, it should match what is deployed
@@ -10,7 +10,7 @@ message ApplicationNodeConfig {
 
     // Application specific configuration, will be loaded by
     // the custom application during runtime
-    google.protobuf.Struct parameters = 2;
+    google.protobuf.Any parameters = 2;
 }
 
 message ApplicationNodeStatus {


### PR DESCRIPTION
# Summary
Application developers need a way to send generic application configuration. This provides that mechanism.

We can have users define a Protobuf message for their configuration like this:

```
message MyCustomParamters {
  float value = 1;
  string other = 2;
}
```


In C++, you can use it like this:

```c++
auto* app_config = node->mutable_application();

MyCustomParameters params;
params.set_value(12);

app_config->mutable_parameters()->PackFrom(params);

// Reading
const auto& params = app_config.parameters();
if (params.Is<MyCustomParameters>()) {
  MyCustomParameters out_params;
  params.UnpackTo(&out_params);
}
```

# Changes
* Added parameters field to the ApplicationNodeConfig

# Testing
 - n/a

