### PR TITLE
Fix: use struct for configuration parameters

### DIFF
--- a/api/app.proto
+++ b/api/app.proto
@@ -5,15 +5,17 @@ package synapse;
 import "api/status.proto";
 import "api/performance.proto";
 
+import "google/protobuf/struct.proto";
+
 message AppManifest {
   // Your application name
   string name = 1;
 
-  // Path to the JSON Schema file for validating application configuration
-  string config_schema_path = 2;
+  // JSON Schema for validating configuration
+  google.protobuf.Struct config_schema = 2;
 
-  // Path to the DeviceConfiguration, in json, relative to the manifest file
-  string device_config_path = 3;
+  // DeviceConfiguration describing the signal chain/device config
+  google.protobuf.Struct device_config = 3;
 }
 
 message PackageMetadata {

--- a/api/app.proto
+++ b/api/app.proto
@@ -9,9 +9,8 @@ message AppManifest {
   // Your application name
   string name = 1;
 
-  // Additional proto files provided by the developer, relative to the manifest file
-  // We need these to generate type descriptors for use with Any types
-  repeated string proto_files = 2;
+  // Path to the JSON Schema file for validating application configuration
+  string config_schema_path = 2;
 
   // Path to the DeviceConfiguration, in json, relative to the manifest file
   string device_config_path = 3;

--- a/api/app.proto
+++ b/api/app.proto
@@ -4,6 +4,7 @@ package synapse;
 
 import "api/status.proto";
 import "api/performance.proto";
+import "api/device.proto";
 
 import "google/protobuf/struct.proto";
 
@@ -15,7 +16,7 @@ message AppManifest {
   google.protobuf.Struct config_schema = 2;
 
   // DeviceConfiguration describing the signal chain/device config
-  google.protobuf.Struct device_config = 3;
+  DeviceConfiguration device_config = 3;
 }
 
 message PackageMetadata {

--- a/api/device.proto
+++ b/api/device.proto
@@ -1,0 +1,38 @@
+syntax = "proto3";
+
+package synapse;
+
+import "api/node.proto";
+import "api/status.proto";
+
+message Peripheral {
+    enum Type {
+      kUnknown = 0;
+      kBroadbandSource = 1;
+      kElectricalStimulation = 2;
+      kOpticalStimulation = 3;
+      kSpikeSource = 4;
+    }
+    string name = 1;
+    string vendor = 2;
+    uint32 peripheral_id = 3;
+    Type type = 4;
+    string address = 5;
+  }
+  
+
+message DeviceInfo {
+    string name = 1;
+    string serial = 2;
+    uint32 synapse_version = 3;
+    uint32 firmware_version = 4;
+    Status status = 5;
+    repeated Peripheral peripherals = 6;
+    DeviceConfiguration configuration = 7;
+  }
+  
+  message DeviceConfiguration {
+    repeated NodeConfig nodes = 1;
+    repeated NodeConnection connections = 2;
+  }
+  

--- a/api/device.proto
+++ b/api/device.proto
@@ -18,7 +18,7 @@ message Peripheral {
     uint32 peripheral_id = 3;
     Type type = 4;
     string address = 5;
-  }
+}
   
 
 message DeviceInfo {
@@ -29,10 +29,9 @@ message DeviceInfo {
     Status status = 5;
     repeated Peripheral peripherals = 6;
     DeviceConfiguration configuration = 7;
-  }
-  
-  message DeviceConfiguration {
+}
+
+message DeviceConfiguration {
     repeated NodeConfig nodes = 1;
     repeated NodeConnection connections = 2;
-  }
-  
+}

--- a/api/device.proto
+++ b/api/device.proto
@@ -19,7 +19,6 @@ message Peripheral {
     Type type = 4;
     string address = 5;
 }
-  
 
 message DeviceInfo {
     string name = 1;

--- a/api/nodes/application.proto
+++ b/api/nodes/application.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package synapse;
 
-import "google/protobuf/any.proto";
+import "google/protobuf/struct.proto";
 
 message ApplicationNodeConfig {
     // Your application name, it should match what is deployed
@@ -10,7 +10,7 @@ message ApplicationNodeConfig {
 
     // Application specific configuration, will be loaded by
     // the custom application during runtime
-    google.protobuf.Any parameters = 2;
+    google.protobuf.Struct parameters = 2;
 }
 
 message ApplicationNodeStatus {

--- a/api/synapse.proto
+++ b/api/synapse.proto
@@ -3,42 +3,13 @@ syntax = "proto3";
 package synapse;
 
 import "google/protobuf/empty.proto";
-import "api/node.proto";
+
 import "api/query.proto";
 import "api/status.proto";
 import "api/files.proto";
 import "api/logging.proto";
 import "api/app.proto";
-
-message Peripheral {
-  enum Type {
-    kUnknown = 0;
-    kBroadbandSource = 1;
-    kElectricalStimulation = 2;
-    kOpticalStimulation = 3;
-    kSpikeSource = 4;
-  }
-  string name = 1;
-  string vendor = 2;
-  uint32 peripheral_id = 3;
-  Type type = 4;
-  string address = 5;
-}
-
-message DeviceInfo {
-  string name = 1;
-  string serial = 2;
-  uint32 synapse_version = 3;
-  uint32 firmware_version = 4;
-  Status status = 5;
-  repeated Peripheral peripherals = 6;
-  DeviceConfiguration configuration = 7;
-}
-
-message DeviceConfiguration {
-  repeated NodeConfig nodes = 1;
-  repeated NodeConnection connections = 2;
-}
+import "api/device.proto";
 
 service SynapseDevice {
   rpc Info(google.protobuf.Empty) returns (DeviceInfo) {}


### PR DESCRIPTION
# Summary
While conceptually nice, we revert the ability to pass Any as a parameter for app configs, and instead use the Struct. 

Any is tough because:
 - We need to pass around the generated protobuf descriptors for each app to synapsectl (so we can deploy)
 - We lose the ability to serialize to human readable json, the tools need to have the descriptors

If we move to structs we still get runtime type checking through GetXXXValue() methods. The main thing we lose with this is compile time safety.

# Changes
* Provides a path to config schema, not generate protofiles
* Uses Struct instead of any

# Testing
 - Locally. Since this wasn't a release yet, we can re-use these fields without harm
