### PR TITLE
fix: Fall back to map instead of struct

### DIFF
--- a/api/nodes/application.proto
+++ b/api/nodes/application.proto
@@ -2,15 +2,13 @@ syntax = "proto3";
 
 package synapse;
 
-import "google/protobuf/struct.proto";
-
 message ApplicationNodeConfig {
     // Your application name, it should match what is deployed
     string name = 1;
 
     // Application specific configuration, will be loaded by
     // the custom application during runtime
-    google.protobuf.Struct parameters = 2;
+    map<string, google.protobuf.Value> parameters = 2;
 }
 
 message ApplicationNodeStatus {

--- a/api/nodes/application.proto
+++ b/api/nodes/application.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package synapse;
 
+import "google/protobuf/struct.proto";
+
 message ApplicationNodeConfig {
     // Your application name, it should match what is deployed
     string name = 1;


### PR DESCRIPTION
# Summary
Small change, but it seems like the Struct message type has some ergonomic issues, at least with our version of protobuf being used on the C++ side (e.g. field.count(key) doesn't actually return keys that are definitely there when iterating through the fields manually).

Might be a hint because they don't have docs on Structs: https://protobuf.dev/reference/cpp/cpp-generated/

# Changes
* Swap out Struct for map

# Testing
 - Tested locally. Accessors work as expected. 
