### PR TITLE
Feature: Add support for recording from aux channels

### DIFF
--- a/api/channel.proto
+++ b/api/channel.proto
@@ -2,8 +2,26 @@ syntax = "proto3";
 
 package synapse;
 
+enum ChannelType {
+  ELECTRODE = 0;
+  TTL = 1;
+}
+
 message Channel {
   uint32 id = 1;
   uint32 electrode_id = 2;
   uint32 reference_id = 3;
+  ChannelType type = 4;
+}
+
+// Describes contiguous ranges of channel types in frame_data, in order.
+// Example:
+// [{type: ELECTRODE}, count: 64, {type:TTL, count:3, channel_ids:[0, 2, 5]}]
+// This means frame_data[0..63] are electrodes, frame_data[64..66] are TTL lines 0, 2, 5
+message ChannelRange {
+    ChannelType type = 1;
+    uint32 count = 2;
+    // Optional: for non-contiguous channels (e.g., TTL), specifies which
+    //           channel ids are included, in order. Empty for contiguous
+    repeated uint32 channel_ids = 3;
 }

--- a/api/channel.proto
+++ b/api/channel.proto
@@ -14,10 +14,6 @@ message Channel {
   ChannelType type = 4;
 }
 
-// Describes contiguous ranges of channel types in frame_data, in order.
-// Example:
-// [{type: ELECTRODE}, count: 64, {type:TTL, count:3, channel_ids:[0, 2, 5]}]
-// This means frame_data[0..63] are electrodes, frame_data[64..66] are TTL lines 0, 2, 5
 message ChannelRange {
     ChannelType type = 1;
     uint32 count = 2;

--- a/api/datatype.proto
+++ b/api/datatype.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package synapse;
 
 import "google/protobuf/struct.proto";
+import "api/channel.proto";
 
 enum DataType {
     kDataTypeUnknown = 0;

--- a/api/datatype.proto
+++ b/api/datatype.proto
@@ -70,6 +70,10 @@ message BroadbandFrame {
   uint32 sample_rate_hz = 4;
 
   // When empty, all frame_data entries are electrode channels (legacy behavior).
+  // Describes contiguous ranges of channel types in frame_data, in order.
+  // Example:
+  // [{type: ELECTRODE}, count: 64, {type:TTL, count:3, channel_ids:[0, 2, 5]}]
+  // This means frame_data[0..63] are electrodes, frame_data[64..66] are TTL lines 0, 2, 5
   repeated ChannelRange channel_ranges = 5;
 }
 

--- a/api/datatype.proto
+++ b/api/datatype.proto
@@ -68,6 +68,27 @@ message BroadbandFrame {
 
   // Used for reconstructing multiple frames
   uint32 sample_rate_hz = 4;
+
+  // Describes contiguous ranges of channel types in frame_data, in order.
+  // When empty, all frame_data entries are electrode channels (legacy behavior).
+  // Example: 
+  // [{type: ELECTRODE}, count: 64, {type:TTL, count:3, channel_ids:[0, 2, 5]}]
+  // This means frame_data[0..63] are electrodes, frame_data[64..66] are TTL lines 0, 2, 5
+  message ChannelRange {
+    enum ChannelType {
+      ELECTRODE = 0;
+      TTL = 1;
+    }
+    ChannelType type = 1;
+
+    // Number of channels of this type in frame_data
+    uint32 count = 2;
+
+    // Optional: for non-contiguous channels (e.g., TTL), specifies which
+    //           channel ids are included, in order. Empty for contiguous
+    repeated uint32 channel_ids = 3;
+  }
+  repeated ChannelRange channel_ranges = 5;
 }
 
 message Timeseries {

--- a/api/datatype.proto
+++ b/api/datatype.proto
@@ -69,25 +69,7 @@ message BroadbandFrame {
   // Used for reconstructing multiple frames
   uint32 sample_rate_hz = 4;
 
-  // Describes contiguous ranges of channel types in frame_data, in order.
   // When empty, all frame_data entries are electrode channels (legacy behavior).
-  // Example: 
-  // [{type: ELECTRODE}, count: 64, {type:TTL, count:3, channel_ids:[0, 2, 5]}]
-  // This means frame_data[0..63] are electrodes, frame_data[64..66] are TTL lines 0, 2, 5
-  message ChannelRange {
-    enum ChannelType {
-      ELECTRODE = 0;
-      TTL = 1;
-    }
-    ChannelType type = 1;
-
-    // Number of channels of this type in frame_data
-    uint32 count = 2;
-
-    // Optional: for non-contiguous channels (e.g., TTL), specifies which
-    //           channel ids are included, in order. Empty for contiguous
-    repeated uint32 channel_ids = 3;
-  }
   repeated ChannelRange channel_ranges = 5;
 }
 

--- a/api/nodes/signal_config.proto
+++ b/api/nodes/signal_config.proto
@@ -11,23 +11,6 @@ message ElectrodeConfig {
     // Analog filter settings for electrode channels
     float low_cutoff_hz = 2;
     float high_cutoff_hz = 3;
-
-    // Additional data channels to record beyond electrodes
-    // These will appear in the broadband data stream after electrode
-    // channels in the order specified here
-    message AuxiliaryChannel {
-        enum ChannelType {
-            TTL = 0;  // Digital input line
-        }
-        ChannelType type = 1;
-
-        // Channel identifier (TTL line 0-31, etc.)
-        uint32 channel_id = 2;
-
-        // Optional human-readable label
-        string label = 3;
-    }
-    repeated AuxiliaryChannel auxiliary_channels = 4;
 }
 
 message PixelConfig {

--- a/api/nodes/signal_config.proto
+++ b/api/nodes/signal_config.proto
@@ -5,9 +5,29 @@ import "api/channel.proto";
 package synapse;
 
 message ElectrodeConfig {
+    // Electrode recording channels
     repeated Channel channels = 1;
+
+    // Analog filter settings for electrode channels
     float low_cutoff_hz = 2;
     float high_cutoff_hz = 3;
+
+    // Additional data channels to record beyond electrodes
+    // These will appear in the broadband data stream after electrode
+    // channels in the order specified here
+    message AuxiliaryChannel {
+        enum ChannelType {
+            TTL = 0;  // Digital input line
+        }
+        ChannelType type = 1;
+
+        // Channel identifier (TTL line 0-31, etc.)
+        uint32 channel_id = 2;
+
+        // Optional human-readable label
+        string label = 3;
+    }
+    repeated AuxiliaryChannel auxiliary_channels = 4;
 }
 
 message PixelConfig {

--- a/api/nodes/signal_config.proto
+++ b/api/nodes/signal_config.proto
@@ -5,7 +5,6 @@ import "api/channel.proto";
 package synapse;
 
 message ElectrodeConfig {
-    // Electrode and/or TTL recording channels
     repeated Channel channels = 1;
 
     // Analog filter settings for electrode channels

--- a/api/nodes/signal_config.proto
+++ b/api/nodes/signal_config.proto
@@ -5,7 +5,7 @@ import "api/channel.proto";
 package synapse;
 
 message ElectrodeConfig {
-    // Electrode recording channels
+    // Electrode and/or TTL recording channels
     repeated Channel channels = 1;
 
     // Analog filter settings for electrode channels


### PR DESCRIPTION
# Summary
We would like to support users to be able to record GPIO data with broadband data. These changes support that. This is in an effort to not have the clients care about timing at all - everything is in the same logical message with the same timestamp.

# Changes
* Adds a channel range type to the BroadbandFrame. frame_data will be appended with aux data, indexed according to the message
* adds configuration options to the electrode config to configure ttl channels. leaves support for adc in the future as we get there. 

# Testing
 - builds, should be backwards compatible
