### PR TITLE
Ns/ttl to gpio rename

### DIFF
--- a/api/channel.proto
+++ b/api/channel.proto
@@ -4,7 +4,7 @@ package synapse;
 
 enum ChannelType {
   ELECTRODE = 0;
-  TTL = 1;
+  GPIO = 1;
 }
 
 message Channel {
@@ -17,7 +17,7 @@ message Channel {
 message ChannelRange {
     ChannelType type = 1;
     uint32 count = 2;
-    // Optional: for non-contiguous channels (e.g., TTL), specifies which
+    // Optional: for non-contiguous channels (e.g., GPIO), specifies which
     //           channel ids are included, in order. Empty for contiguous
     repeated uint32 channel_ids = 3;
 }

--- a/api/channel.proto
+++ b/api/channel.proto
@@ -2,8 +2,26 @@ syntax = "proto3";
 
 package synapse;
 
+enum ChannelType {
+  ELECTRODE = 0;
+  TTL = 1;
+}
+
 message Channel {
   uint32 id = 1;
   uint32 electrode_id = 2;
   uint32 reference_id = 3;
+  ChannelType type = 4;
+}
+
+// Describes contiguous ranges of channel types in frame_data, in order.
+// Example:
+// [{type: ELECTRODE}, count: 64, {type:TTL, count:3, channel_ids:[0, 2, 5]}]
+// This means frame_data[0..63] are electrodes, frame_data[64..66] are TTL lines 0, 2, 5
+message ChannelRange {
+    ChannelType type = 1;
+    uint32 count = 2;
+    // Optional: for non-contiguous channels (e.g., TTL), specifies which
+    //           channel ids are included, in order. Empty for contiguous
+    repeated uint32 channel_ids = 3;
 }

--- a/api/channel.proto
+++ b/api/channel.proto
@@ -14,10 +14,6 @@ message Channel {
   ChannelType type = 4;
 }
 
-// Describes contiguous ranges of channel types in frame_data, in order.
-// Example:
-// [{type: ELECTRODE}, count: 64, {type:TTL, count:3, channel_ids:[0, 2, 5]}]
-// This means frame_data[0..63] are electrodes, frame_data[64..66] are TTL lines 0, 2, 5
 message ChannelRange {
     ChannelType type = 1;
     uint32 count = 2;

--- a/api/datatype.proto
+++ b/api/datatype.proto
@@ -66,6 +66,27 @@ message BroadbandFrame {
 
   // Used for reconstructing multiple frames
   uint32 sample_rate_hz = 4;
+
+  // Describes contiguous ranges of channel types in frame_data, in order.
+  // When empty, all frame_data entries are electrode channels (legacy behavior).
+  // Example: 
+  // [{type: ELECTRODE}, count: 64, {type:TTL, count:3, channel_ids:[0, 2, 5]}]
+  // This means frame_data[0..63] are electrodes, frame_data[64..66] are TTL lines 0, 2, 5
+  message ChannelRange {
+    enum ChannelType {
+      ELECTRODE = 0;
+      TTL = 1;
+    }
+    ChannelType type = 1;
+
+    // Number of channels of this type in frame_data
+    uint32 count = 2;
+
+    // Optional: for non-contiguous channels (e.g., TTL), specifies which
+    //           channel ids are included, in order. Empty for contiguous
+    repeated uint32 channel_ids = 3;
+  }
+  repeated ChannelRange channel_ranges = 5;
 }
 
 message Timeseries {

--- a/api/datatype.proto
+++ b/api/datatype.proto
@@ -72,8 +72,8 @@ message BroadbandFrame {
   // When empty, all frame_data entries are electrode channels (legacy behavior).
   // Describes contiguous ranges of channel types in frame_data, in order.
   // Example:
-  // [{type: ELECTRODE}, count: 64, {type:TTL, count:3, channel_ids:[0, 2, 5]}]
-  // This means frame_data[0..63] are electrodes, frame_data[64..66] are TTL lines 0, 2, 5
+  // [{type: ELECTRODE}, count: 64, {type:GPIO, count:3, channel_ids:[0, 2, 5]}]
+  // This means frame_data[0..63] are electrodes, frame_data[64..66] are GPIO lines 0, 2, 5
   repeated ChannelRange channel_ranges = 5;
 }
 

--- a/api/datatype.proto
+++ b/api/datatype.proto
@@ -68,6 +68,10 @@ message BroadbandFrame {
   uint32 sample_rate_hz = 4;
 
   // When empty, all frame_data entries are electrode channels (legacy behavior).
+  // Describes contiguous ranges of channel types in frame_data, in order.
+  // Example:
+  // [{type: ELECTRODE}, count: 64, {type:TTL, count:3, channel_ids:[0, 2, 5]}]
+  // This means frame_data[0..63] are electrodes, frame_data[64..66] are TTL lines 0, 2, 5
   repeated ChannelRange channel_ranges = 5;
 }
 

--- a/api/datatype.proto
+++ b/api/datatype.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package synapse;
 
+import "api/channel.proto";
+
 enum DataType {
     kDataTypeUnknown = 0;
     kAny = 1;

--- a/api/datatype.proto
+++ b/api/datatype.proto
@@ -67,25 +67,7 @@ message BroadbandFrame {
   // Used for reconstructing multiple frames
   uint32 sample_rate_hz = 4;
 
-  // Describes contiguous ranges of channel types in frame_data, in order.
   // When empty, all frame_data entries are electrode channels (legacy behavior).
-  // Example: 
-  // [{type: ELECTRODE}, count: 64, {type:TTL, count:3, channel_ids:[0, 2, 5]}]
-  // This means frame_data[0..63] are electrodes, frame_data[64..66] are TTL lines 0, 2, 5
-  message ChannelRange {
-    enum ChannelType {
-      ELECTRODE = 0;
-      TTL = 1;
-    }
-    ChannelType type = 1;
-
-    // Number of channels of this type in frame_data
-    uint32 count = 2;
-
-    // Optional: for non-contiguous channels (e.g., TTL), specifies which
-    //           channel ids are included, in order. Empty for contiguous
-    repeated uint32 channel_ids = 3;
-  }
   repeated ChannelRange channel_ranges = 5;
 }
 

--- a/api/nodes/signal_config.proto
+++ b/api/nodes/signal_config.proto
@@ -11,23 +11,6 @@ message ElectrodeConfig {
     // Analog filter settings for electrode channels
     float low_cutoff_hz = 2;
     float high_cutoff_hz = 3;
-
-    // Additional data channels to record beyond electrodes
-    // These will appear in the broadband data stream after electrode
-    // channels in the order specified here
-    message AuxiliaryChannel {
-        enum ChannelType {
-            TTL = 0;  // Digital input line
-        }
-        ChannelType type = 1;
-
-        // Channel identifier (TTL line 0-31, etc.)
-        uint32 channel_id = 2;
-
-        // Optional human-readable label
-        string label = 3;
-    }
-    repeated AuxiliaryChannel auxiliary_channels = 4;
 }
 
 message PixelConfig {

--- a/api/nodes/signal_config.proto
+++ b/api/nodes/signal_config.proto
@@ -5,9 +5,29 @@ import "api/channel.proto";
 package synapse;
 
 message ElectrodeConfig {
+    // Electrode recording channels
     repeated Channel channels = 1;
+
+    // Analog filter settings for electrode channels
     float low_cutoff_hz = 2;
     float high_cutoff_hz = 3;
+
+    // Additional data channels to record beyond electrodes
+    // These will appear in the broadband data stream after electrode
+    // channels in the order specified here
+    message AuxiliaryChannel {
+        enum ChannelType {
+            TTL = 0;  // Digital input line
+        }
+        ChannelType type = 1;
+
+        // Channel identifier (TTL line 0-31, etc.)
+        uint32 channel_id = 2;
+
+        // Optional human-readable label
+        string label = 3;
+    }
+    repeated AuxiliaryChannel auxiliary_channels = 4;
 }
 
 message PixelConfig {

--- a/api/nodes/signal_config.proto
+++ b/api/nodes/signal_config.proto
@@ -5,7 +5,6 @@ import "api/channel.proto";
 package synapse;
 
 message ElectrodeConfig {
-    // Electrode and/or TTL recording channels
     repeated Channel channels = 1;
 
     // Analog filter settings for electrode channels

--- a/api/nodes/signal_config.proto
+++ b/api/nodes/signal_config.proto
@@ -5,7 +5,7 @@ import "api/channel.proto";
 package synapse;
 
 message ElectrodeConfig {
-    // Electrode recording channels
+    // Electrode and/or TTL recording channels
     repeated Channel channels = 1;
 
     // Analog filter settings for electrode channels


### PR DESCRIPTION
# Summary
Sub "TTL" in favor for "GPIO". While there are nice connotations with the TTL acronym, it by definition is 5V (or 3.3V for LVTTL). 5V will kill current axon probes inputs. 

# Changes
* s/TTL/GPIO/g

# Testing
See: https://github.com/sciencecorp/headstage/pull/284


