### PR TITLE
Rename TTL to GPIO

### DIFF
--- a/api/channel.proto
+++ b/api/channel.proto
@@ -4,7 +4,7 @@ package synapse;
 
 enum ChannelType {
   ELECTRODE = 0;
-  TTL = 1;
+  GPIO = 1;
 }
 
 message Channel {
@@ -17,7 +17,7 @@ message Channel {
 message ChannelRange {
     ChannelType type = 1;
     uint32 count = 2;
-    // Optional: for non-contiguous channels (e.g., TTL), specifies which
+    // Optional: for non-contiguous channels (e.g., GPIO), specifies which
     //           channel ids are included, in order. Empty for contiguous
     repeated uint32 channel_ids = 3;
 }

--- a/api/datatype.proto
+++ b/api/datatype.proto
@@ -73,8 +73,8 @@ message BroadbandFrame {
   // When empty, all frame_data entries are electrode channels (legacy behavior).
   // Describes contiguous ranges of channel types in frame_data, in order.
   // Example:
-  // [{type: ELECTRODE}, count: 64, {type:TTL, count:3, channel_ids:[0, 2, 5]}]
-  // This means frame_data[0..63] are electrodes, frame_data[64..66] are TTL lines 0, 2, 5
+  // [{type: ELECTRODE}, count: 64, {type:GPIO, count:3, channel_ids:[0, 2, 5]}]
+  // This means frame_data[0..63] are electrodes, frame_data[64..66] are GPIO lines 0, 2, 5
   repeated ChannelRange channel_ranges = 5;
 }
 


### PR DESCRIPTION
# Summary
Sub "TTL" in favor for "GPIO". While there are nice connotations with the TTL acronym, it by definition is 5V (or 3.3V for LVTTL). 5V will kill current axon probes inputs. 

# Changes
* s/TTL/GPIO/g

# Testing
See: https://github.com/sciencecorp/headstage/pull/284

