### PR TITLE
feature: Proposal for optical stim frame

### DIFF
--- a/api/datatype.proto
+++ b/api/datatype.proto
@@ -107,19 +107,3 @@ message AnnotatedTensor {
   // e.g. pipeline latencies
   map<string, google.protobuf.Value> metadata = 2;
 }
-
-// Core frame type for LED array optical stimulation
-message OpticalStimFrame {
-  uint64 frame_id = 1;
-  uint64 sequence_number = 2;
-  uint64 timestamp_ns = 3;
-
-  // Frame dimensions
-  uint32 rows = 4;
-  uint32 columns = 5;
-
-  // Normalized pixel intensities (0.0 - 1.0)
-  // Row major ordering
-  // 0.0 is completely off, 1.0 is completely on
-  repeated float pixels = 6;
-}

--- a/api/datatype.proto
+++ b/api/datatype.proto
@@ -107,3 +107,19 @@ message AnnotatedTensor {
   // e.g. pipeline latencies
   map<string, google.protobuf.Value> metadata = 2;
 }
+
+// Core frame type for LED array optical stimulation
+message OpticalStimFrame {
+  uint64 frame_id = 1;
+  uint64 sequence_number = 2;
+  uint64 timestamp_ns = 3;
+
+  // Frame dimensions
+  uint32 rows = 4;
+  uint32 columns = 5;
+
+  // Normalized pixel intensities (0.0 - 1.0)
+  // Row major ordering
+  // 0.0 is completely off, 1.0 is completely on
+  repeated float pixels = 6;
+}

--- a/api/nodes/optical_stimulation.proto
+++ b/api/nodes/optical_stimulation.proto
@@ -9,3 +9,19 @@ message OpticalStimulationConfig {
   uint32 frame_rate = 4;
   float gain = 5;
 }
+
+// Core frame type for LED array optical stimulation
+message OpticalStimFrame {
+  uint64 frame_id = 1;
+  uint64 sequence_number = 2;
+  uint64 timestamp_ns = 3;
+
+  // Frame dimensions
+  uint32 rows = 4;
+  uint32 columns = 5;
+
+  // Normalized pixel intensities (0.0 - 1.0)
+  // Row major ordering
+  // 0.0 is completely off, 1.0 is completely on
+  repeated float pixels = 6;
+}

--- a/api/nodes/optical_stimulation.proto
+++ b/api/nodes/optical_stimulation.proto
@@ -31,5 +31,5 @@ message OpticalStimFrame {
 
   // For passive displays, this represents the row on time
   // For active, this represents frame on time
-  uint64 duration_ns = 7;
+  uint64 duration_us = 7;
 }

--- a/api/nodes/optical_stimulation.proto
+++ b/api/nodes/optical_stimulation.proto
@@ -8,6 +8,10 @@ message OpticalStimulationConfig {
   uint32 bit_width = 3;
   uint32 frame_rate = 4;
   float gain = 5;
+
+  // Instruct the FPGA to send out a 1xN vector 
+  // where N is the number of LEDs with each Axon frame
+  bool send_receipts = 6;
 }
 
 // Core frame type for LED array optical stimulation

--- a/api/nodes/optical_stimulation.proto
+++ b/api/nodes/optical_stimulation.proto
@@ -23,5 +23,9 @@ message OpticalStimFrame {
   // Normalized pixel intensities (0.0 - 1.0)
   // Row major ordering
   // 0.0 is completely off, 1.0 is completely on
-  repeated float pixels = 6;
+  repeated float intensity = 6;
+
+  // For passive displays, this represents the row on time
+  // For active, this represents frame on time
+  uint64 duration_ns = 7;
 }


### PR DESCRIPTION
# Summary
In order to support LED based stimulation, we need to define an optical stim frame. 

Biggest question is around the pixel representation. Does 0.0 -> 1.0 normalized intensity make sense? Or do we want to use an integer representation? Or flexibility with bytes and something like a PixelFormat enum

# Changes
* Adds OpticalStimFrame

# Testing
- builds

