### PR TITLE
feature: add disk writer status

### DIFF
--- a/api/node.proto
+++ b/api/node.proto
@@ -62,6 +62,7 @@ message NodeStatus {
     ElectricalStimulationStatus electrical_stimulation = 6;
     ApplicationNodeStatus application = 7;
     OpticalStimulationStatus optical_stimulation = 8;
+    DiskWriterStatus disk_writer = 10;
   }
 }
 

--- a/api/nodes/disk_writer.proto
+++ b/api/nodes/disk_writer.proto
@@ -20,5 +20,5 @@ message DiskWriterStatus {
   uint64 available_disk_space_bytes = 4;
 
   // Current write performance for this node, megabits/sec
-  float current_bitrate_mbps = 8;
+  float current_bitrate_mbps = 5;
 }

--- a/api/nodes/disk_writer.proto
+++ b/api/nodes/disk_writer.proto
@@ -5,3 +5,20 @@ package synapse;
 message DiskWriterConfig {
   string filename = 1;
 }
+
+message DiskWriterStatus {
+  // The output path of the file on the path of the sftp directory
+  string output_path = 1;
+
+  // How many bytes has been written for this file?
+  uint64 bytes_written = 2;
+
+  // Are we currently writing or are we stopped?
+  bool is_writing = 3;
+
+  // How many bytes are available for us to use
+  uint64 available_disk_space_bytes = 4;
+
+  // Current write performance for this node, megabits/sec
+  float current_bitrate_mbps = 8;
+}


### PR DESCRIPTION
# Summary
We had a case where the disk writer was writing too much data to disk, and the disk filled up. We don't want that to happen, so a user should be able to see the status of a disk writer in progress. 

# Changes
* Added DiskWriter node status

# Testing
- builds.
