### PR TITLE
feature: Add configurable clock freq

### DIFF
--- a/api/device.proto
+++ b/api/device.proto
@@ -41,6 +41,9 @@ message DeviceConfiguration {
 message DeviceSettings {
     string name = 1;
     TimeSource time_source = 2;
+
+    // If configurable, the desired FPGA clock frequency in hz
+    uint32 fpga_clock_freq_hz = 3;
 }
 
 message GetSettingsQuery {


### PR DESCRIPTION
# Summary
For the chips we provide, there are options of the FPGA clock frequency. Allow users to set it, but the server will validate that it is a correct clock frequency.

# Changes
* Added fpga_clock_freq_hz to device settings

