### PR TITLE
Add ListApps RPC for querying installed applications

### DIFF
--- a/api/app.proto
+++ b/api/app.proto
@@ -53,3 +53,19 @@ message AppPerformanceSummary {
   uint64 timestamp_ns = 1;
   repeated FunctionProfile function_profiles = 2;
 }
+
+// Information about an installed application
+message AppInfo {
+  // Application name (e.g., "synapse-example-app")
+  string name = 1;
+
+  // Installed version
+  string version = 2;
+}
+
+message ListAppsRequest {
+}
+
+message ListAppsResponse {
+  repeated AppInfo apps = 1;
+}

--- a/api/synapse.proto
+++ b/api/synapse.proto
@@ -20,6 +20,7 @@ service SynapseDevice {
   rpc StreamQuery(StreamQueryRequest) returns (stream StreamQueryResponse) {}
 
   rpc DeployApp(stream AppPackageChunk) returns (stream AppDeployResponse) {}
+  rpc ListApps(ListAppsRequest) returns (ListAppsResponse) {}
 
   rpc ListFiles(google.protobuf.Empty) returns (ListFilesResponse) {}
   rpc WriteFile(WriteFileRequest) returns (WriteFileResponse) {}


### PR DESCRIPTION
## Summary
- Add `AppInfo` message with name and version fields
- Add `ListAppsRequest` and `ListAppsResponse` messages
- Add `ListApps` RPC to `SynapseDevice` service

This enables clients to query the list of installed applications on a device, complementing the existing `DeployApp` RPC.

## Test plan
- [ ] Proto compiles successfully
- [ ] Dependent PRs in synapse-python, synapse-typescript, and nexus-desktop