### PR TITLE
feature: added support for multiple storage devices for DiskWriter to target (SD cards for SciFi2)

### DIFF
--- a/api/nodes/disk_writer.proto
+++ b/api/nodes/disk_writer.proto
@@ -3,14 +3,11 @@ syntax = "proto3";
 package synapse;
 
 message DiskWriterConfig {
-  enum WriteTarget {
-    kUnknown = 0;
-    kDisk = 1;
-    kSdCard = 2;
-  }
-
   string filename = 1;
-  WriteTarget write_target = 2;
+
+  // String specifying storage device, decided by the implementer
+  // e.g. "disk", "sdcard1", "sdcard2"
+  string storage_device_name = 2;
 }
 
 message DiskWriterStatus {

--- a/api/nodes/disk_writer.proto
+++ b/api/nodes/disk_writer.proto
@@ -3,7 +3,14 @@ syntax = "proto3";
 package synapse;
 
 message DiskWriterConfig {
+  enum WriteTarget {
+    kUnknown = 0;
+    kDisk = 1;
+    kSdCard = 2;
+  }
+
   string filename = 1;
+  WriteTarget write_target = 2;
 }
 
 message DiskWriterStatus {

--- a/api/nodes/disk_writer.proto
+++ b/api/nodes/disk_writer.proto
@@ -4,10 +4,7 @@ package synapse;
 
 message DiskWriterConfig {
   string filename = 1;
-
-  // String specifying storage device, decided by the implementer
-  // e.g. "disk", "sdcard1", "sdcard2"
-  string storage_device_name = 2;
+  uint32 storage_device_id = 2;
 }
 
 message DiskWriterStatus {

--- a/api/status.proto
+++ b/api/status.proto
@@ -23,9 +23,16 @@ enum DeviceState {
   kError = 4;
 }
 
+message StorageDeviceStatus {
+  // Human-readable name decided by implementer, 
+  // can be dynamic on runtime, e.g. "disk", "sdcard1", "sdcard2"
+  string name = 1;
+  float total_gb = 2;
+  float used_gb = 3;
+}
+
 message DeviceStorage {
-  float total_gb = 1;
-  float used_gb = 2;
+  repeated StorageDeviceStatus storage_devices;
 }
 
 message DevicePower {

--- a/api/status.proto
+++ b/api/status.proto
@@ -31,7 +31,8 @@ message StorageDevice {
 }
 
 message DeviceStorage {
-  repeated StorageDevice storage_devices = 1;
+  reserved 1, 2;
+  repeated StorageDevice storage_devices = 3;
 }
 
 message DevicePower {

--- a/api/status.proto
+++ b/api/status.proto
@@ -23,16 +23,15 @@ enum DeviceState {
   kError = 4;
 }
 
-message StorageDeviceStatus {
-  // Human-readable name decided by implementer, 
-  // can be dynamic on runtime, e.g. "disk", "sdcard1", "sdcard2"
+message StorageDevice {
   string name = 1;
-  float total_gb = 2;
-  float used_gb = 3;
+  uint32 storage_device_id = 2;
+  float total_gb = 3;
+  float used_gb = 4;
 }
 
 message DeviceStorage {
-  repeated StorageDeviceStatus storage_devices;
+  repeated StorageDevice storage_devices = 1;
 }
 
 message DevicePower {


### PR DESCRIPTION
# Summary
The goal of this change is to allow Synapse devices to have an arbitrary amount of storage devices and to allow DiskWriter to write to any of them.

Concretely, we want to add the ability to mount (removable? TBD) SD cards to SciFi2 and for DiskWriter to be able to write to them. However, there are many conflicting factors to consider: user ease-of-use, API readability, and generalizability. With these factors in mind, I later detail the pros and cons of many ideas that me and Max R arrived at.

# Changes
* Added a uint32 field `storage_device_id` to `DiskWriterConfig`. This is an ID that is specified by the implementer of the Synapse API that should correspond to a certain storage device, e.g. {1: "Disk", 2: "SD Card 1", 3: "SD Card 2"}.
* Changed `DeviceStorage` to instead be a repeated `StorageDevice`, with a `StorageDevice` being described by a string corresponding to a human-readable name of the storage, a unique ID decided by the implementer, and the usual `total_gb` and `used_gb`.

# Typical Use Case
Thus, a typical use case for the user would be to first perform an INFO request to see the available storage devices from the `DeviceStorage` list. Concretely, it may look like:

```
Name: accurate-elite-mongrel
Status: Stopped
Serial: SFI_DEVKIT1
Synapse Version: 1
Firmware Version: 14134684
Battery: 100.0%
Storage Devices:
├── Disk:
│   ├── ID: 1
│   └── Storage: 60.7% used (59.6GB / 98.2GB)
├── SD Card 1
│   ├── ID: 2
│   └── Storage: 1.0% used (10.1GB / 1000.0GB)
Peripherals
...
```
Then, they configure DiskWriter with storage_device_id = 1 if they want to write to disk, and storage_device_id = 2 if they want to write to an SD card.

Concretely, for the SciFi2, mounted SD cards will be mounted to `/opt/scifi/data/disk_writer/sd_card`, which users will be able to interact with the usual `file` commands in Synapse CLI.

# Alternative ideas we considered
## String instead of uint32 as unique identifier
We could get rid of the storage IDs and to have the user instead write the human-readable name that is decided by the implementer.

Pros: 
- Makes it much harder to typo

Cons:
- Is much more annoying for the user

## StorageTarget enum
Introduce a `StorageTarget` enum in DiskWriter with {kUnknown, kDisk, KSdCard}.

Pros:
- Is very natural

Cons:
- Doesn't generalize well
- Would need to have `DeviceStorage` return a list of pairs of { .used_gb, .total_gb } that is dependent on the ordering of the enum, OR would have to have it map enums to pairs which is ugly

## Have the filesystem take care of everything
We can also just have implementers introduce different storage devices by mounting them to wherever the root of the filesystem exposed to users is. For example, if I attach an SD card to the SciFi, it will automatically show up in `/opt/scifi/data/sd_card`, exposed to the user through the `file` utilities in the Synapse CLI. Then, in the `filename` field of DiskWriter, they would specify the path that they want to save to, i.e. `sd_card/foo` instead of `foo` (since the SFTP root is `/opt/scifi/data`).

Then, for users to see how much storage is in each storage device, a `DeviceStorage` will be a list of triplets: (path, used_gb, total_gb) such that the paths together form a partition of the exposed directory structure with no overlaps.

Pros:
- Very minimal change to the API
- Highly generalizable

Cons:
- Users will have to think about paths and write paths when configuring DiskWriter nodes. The fact that they have to think about paths is a huge turn off imo.