### PR TITLE
Device-implemented Settings fields

### DIFF
--- a/api/device.proto
+++ b/api/device.proto
@@ -4,7 +4,8 @@ package synapse;
 
 import "api/node.proto";
 import "api/status.proto";
-import "api/time.proto";
+
+import "google/protobuf/struct.proto";
 
 message Peripheral {
     enum Type {
@@ -37,13 +38,35 @@ message DeviceConfiguration {
 }
 
 
-// Device settings that are configurable by the user
+// Device settings that are configurable by the user.
+// Keys and value types are defined by the device and advertised via
+// GetSettingsResponse.schema.
 message DeviceSettings {
-    string name = 1;
-    TimeSource time_source = 2;
+    reserved 1, 2, 3;
+    reserved "name", "time_source", "fpga_clock_freq_hz";
 
-    // If configurable, the desired FPGA clock frequency in hz
-    uint32 fpga_clock_freq_hz = 3;
+    google.protobuf.Struct values = 4;
+}
+
+// Describes a single settings key that the device accepts.
+message SettingDescriptor {
+    enum Kind {
+        kKindUnknown = 0;
+        kString = 1;
+        kInt = 2;
+        kDouble = 3;
+        kBool = 4;
+        kEnum = 5;
+    }
+
+    string name = 1;
+    string description = 2;
+    Kind kind = 3;
+    google.protobuf.Value default_value = 4;
+
+    // Allowed values for enum-kind or discrete-set settings
+    // (e.g. valid FPGA clock frequencies).
+    repeated google.protobuf.Value allowed_values = 5;
 }
 
 message GetSettingsQuery {
@@ -52,10 +75,13 @@ message GetSettingsQuery {
 
 message GetSettingsResponse {
     DeviceSettings settings = 1;
+
+    // Describes the keys this device accepts in DeviceSettings.values.
+    repeated SettingDescriptor schema = 2;
 }
 
 message UpdateDeviceSettingsRequest {
-    // If a field isn't populated, it will not be changed
+    // Only keys present in settings.values will be updated.
     DeviceSettings settings = 1;
 }
 


### PR DESCRIPTION
# Summary
The old specification for settings was rather SciFi-specific. It assumed the notion of name, time source, and FPGA clock frequency were valid notions for all Synapse devices, which could be true, but it could also just be generalized. This generalization will likely especially be appreciated once we implement PRIMA as a Synapse device.

This change makes settings defined by the device with the schema for each field returned as part of the GetSettingsResponse.

# Changes
* Removed "name", "time_source", and "fpga_clock_freq_hz" and reserved them to prevent future use of these fields in the case of new client implementations making requests to outdated server implementations
* Added SettingDescriptor to hold information on a setting's fields' schemas
* Updated GetSettingResponse to return the schemas

# Testing
* SciFi implementation: https://github.com/sciencecorp/headstage/commit/e22cb072ead459e4457913e63cfc92c730ac0e8d
* synapse-python implementation: https://github.com/sciencecorp/synapse-python/commit/a5f9c78eb30652f72bcb105758fd842001bbc2e5
* synapse-typescript: shouldn't need changes outside of pinning to newer version of synapse-api, just a thin layer
* nexus-desktop: https://github.com/sciencecorp/nexus-desktop/commit/8f5064073129eb07ba6a772e3315d753475dc734

<img width="930" height="450" alt="image" src="https://github.com/user-attachments/assets/e4726ea1-fd99-4fee-ae78-f9e22b1fd6a2" />
^ synapsectl showing all the fields registered by scifi-server in headstage. Registered a "hello_world" field to 100% guarantee that clients do not need to be aware of the fields at "compile time".

Note that up-to-date clients asking out-of-date SciFis will show that the SciFi has no settings. People will need to update their SciFis. I can make the clients backwards compatible, but that will be a little ugly: will either have to keep the old fields in DeviceSettings, or will have to put legacy protos in all of our clients.